### PR TITLE
Drop automatic metadata update option

### DIFF
--- a/MediaBrowser.Plugins.Anime/Configuration/PluginConfiguration.cs
+++ b/MediaBrowser.Plugins.Anime/Configuration/PluginConfiguration.cs
@@ -29,7 +29,6 @@ namespace MediaBrowser.Plugins.Anime.Configuration
         : BasePluginConfiguration
     {
         public TitlePreferenceType TitlePreference { get; set; }
-        public bool AllowAutomaticMetadataUpdates { get; set; }
         public bool TidyGenreList { get; set; }
         public int MaxGenres { get; set; }
         public bool AddAnimeGenre { get; set; }
@@ -38,7 +37,6 @@ namespace MediaBrowser.Plugins.Anime.Configuration
         public PluginConfiguration()
         {
             TitlePreference = TitlePreferenceType.Localized;
-            AllowAutomaticMetadataUpdates = true;
             TidyGenreList = true;
             MaxGenres = 5;
             AddAnimeGenre = true;

--- a/MediaBrowser.Plugins.Anime/Configuration/configPage.html
+++ b/MediaBrowser.Plugins.Anime/Configuration/configPage.html
@@ -22,12 +22,6 @@
                             </select>
                         </li>
                         <li>
-                            <label for="chkAutomaticUpdates">
-                                Allow Automatic Metadata Updates
-                            </label>
-                            <input id="chkAutomaticUpdates" name="chkAutomaticUpdates" type="checkbox" value="automaticUpdates" />
-                        </li>
-                        <li>
                             <label for="chkTidyGenres">
                                 Tidy Genre List
                             </label>
@@ -73,7 +67,6 @@
                             var page = $.mobile.activePage;
 
                             $('#titleLanguage', page).val(config.TitlePreference).change();
-                            $('#chkAutomaticUpdates', page).checked(config.AllowAutomaticMetadataUpdates).checkboxradio("refresh");
                             $('#chkTidyGenres', page).checked(config.TidyGenreList).checkboxradio("refresh");
                             $('#chkMaxGenres', page).val(config.MaxGenres).change();
                             $('#chkMoveExcessGenresToTags', page).checked(config.MoveExcessGenresToTags).checkboxradio("refresh");
@@ -92,7 +85,6 @@
                         ApiClient.getPluginConfiguration(AnimeConfigurationPage.pluginUniqueId).then(function(config) {
 
                             config.TitlePreference = $('#titleLanguage', page).val();
-                            config.AllowAutomaticMetadataUpdates = $('#chkAutomaticUpdates', page).prop('checked');
                             config.TidyGenreList = $('#chkTidyGenres').prop('checked');
                             config.MaxGenres = $('#chkMaxGenres').val();
                             config.MaxGenres = $('#chkNames').val();


### PR DESCRIPTION
Jellyfin can currently do this itself (Enable advance options when
creating library > refresh metadata every X days).

Also looking at current code compared to when the feature was added, I
am unable to find any code that makes use of this configuration option

Closes https://github.com/jellyfin/jellyfin-plugin-anime/issues/11