### PR TITLE
Fix incorrect AniList ID being used

### DIFF
--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -366,8 +366,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
                             if (ids.Count > 0)
                             {
                                 var firstId = ids.OrderBy(i => i).First().ToString(CultureInfo.InvariantCulture);
-                                // TODO Investigate why Anilist was commented out
-                                series.ProviderIds.Add(ProviderNames.AniList, firstId);
+                                series.ProviderIds.Add(ProviderNames.MyAnimeList, firstId);
                             }
 
                             break;

--- a/Jellyfin.Plugin.Anime/Providers/ProviderNames.cs
+++ b/Jellyfin.Plugin.Anime/Providers/ProviderNames.cs
@@ -5,6 +5,7 @@
         public const string AniDb = "AniDB";
         public const string AniList = "AniList";
         public const string AniSearch = "AniSearch";
+        public const string MyAnimeList = "MyAnimeList";
         public const string Proxer = "Proxer";
     }
 }


### PR DESCRIPTION
Due to change I made
(https://github.com/jellyfin/jellyfin-plugin-anime/commit/211672c885a04ed3dc978135ef8c0a0dd9f9f9d8#diff-a3b336ee9cf78b4920b9b9700718d2da) the AniList metadata provider would use the show ID specific to MAL and not the ID specific to AniList.

Closes https://github.com/jellyfin/jellyfin-plugin-anime/issues/19