### PR TITLE
Fix metadata 403's and Add images to search results

### DIFF
--- a/Jellyfin.Plugin.Anime/Constants.cs
+++ b/Jellyfin.Plugin.Anime/Constants.cs
@@ -1,0 +1,7 @@
+namespace Jellyfin.Plugin.Anime
+{
+    static class Constants
+    {
+        public const string UserAgent = "jellyfin-plugin-anime";
+    }
+}

--- a/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj
+++ b/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Anime</RootNamespace>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
-    <FileVersion>4.0.0</FileVersion>
+    <AssemblyVersion>5.0.0</AssemblyVersion>
+    <FileVersion>5.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         /// The URL for retrieving a list of all anime titles and their AniDB IDs.
         /// </summary>
         private const string TitlesUrl = "http://anidb.net/api/anime-titles.xml.gz";
-        private const string UserAgent = "mediabrowser";
+        private const string UserAgent = "jellyfin-plugin-anime";
 
         private readonly IApplicationPaths _paths;
         private readonly ILogger _logger;

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
@@ -19,7 +19,6 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         /// The URL for retrieving a list of all anime titles and their AniDB IDs.
         /// </summary>
         private const string TitlesUrl = "http://anidb.net/api/anime-titles.xml.gz";
-        private const string UserAgent = "jellyfin-plugin-anime";
 
         private readonly IApplicationPaths _paths;
         private readonly ILogger _logger;
@@ -92,7 +91,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         private static async Task DownloadTitles_static(string titlesFile)
         {
             var client = new WebClient();
-            client.Headers.Add("User-Agent", UserAgent);
+            client.Headers.Add("User-Agent", Constants.UserAgent);
 
             await AniDbSeriesProvider.RequestLimiter.Tick().ConfigureAwait(false);
             await Task.Delay(Plugin.Instance.Configuration.AniDB_wait_time).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
@@ -18,7 +18,8 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         /// <summary>
         /// The URL for retrieving a list of all anime titles and their AniDB IDs.
         /// </summary>
-        private const string TitlesUrl = "http://anidb.net/api/animetitles.xml.gz";
+        private const string TitlesUrl = "http://anidb.net/api/anime-titles.xml.gz";
+        private const string UserAgent = "mediabrowser";
 
         private readonly IApplicationPaths _paths;
         private readonly ILogger _logger;
@@ -79,17 +80,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         private async Task DownloadTitles(string titlesFile)
         {
             _logger.LogDebug("Downloading new AniDB titles file.");
-
-            var client = new WebClient();
-
-            await AniDbSeriesProvider.RequestLimiter.Tick().ConfigureAwait(false);
-            await Task.Delay(Plugin.Instance.Configuration.AniDB_wait_time).ConfigureAwait(false);
-            using (var stream = await client.OpenReadTaskAsync(TitlesUrl))
-            using (var unzipped = new GZipStream(stream, CompressionMode.Decompress))
-            using (var writer = File.Open(titlesFile, FileMode.Create, FileAccess.Write))
-            {
-                await unzipped.CopyToAsync(writer).ConfigureAwait(false);
-            }
+            await DownloadTitles_static(titlesFile);
         }
 
         /// <summary>
@@ -101,6 +92,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         private static async Task DownloadTitles_static(string titlesFile)
         {
             var client = new WebClient();
+            client.Headers.Add("User-Agent", UserAgent);
 
             await AniDbSeriesProvider.RequestLimiter.Tick().ConfigureAwait(false);
             await Task.Delay(Plugin.Instance.Configuration.AniDB_wait_time).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbEpisodeProvider.cs
@@ -154,7 +154,8 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
 
         public Task<HttpResponseInfo> GetImageResponse(string url, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            var imageProvider = new AniDbImageProvider(_httpClient, _configurationManager.ApplicationPaths);
+            return imageProvider.GetImageResponse(url, cancellationToken);
         }
 
         private async Task ParseAdditionalEpisodeXml(FileInfo xml, Episode episode, string metadataLanguage)

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbImageProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbImageProvider.cs
@@ -33,6 +33,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
 
             return await _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             }).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbPersonProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbPersonProvider.cs
@@ -102,6 +102,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
 
             return await _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             }).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -118,6 +118,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
         {
             return _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             });
@@ -522,6 +523,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
 
             var requestOptions = new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 Url = string.Format(SeriesQueryUrl, ClientName, aid),
                 CancellationToken = cancellationToken
             };

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -95,11 +95,15 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
 
             if (metadata.HasMetadata)
             {
+                var seriesId = metadata.Item.ProviderIds.GetOrDefault(ProviderNames.AniDb);
+                var imageProvider = new AniDbImageProvider(_httpClient, _appPaths);
+                var images = await imageProvider.GetImages(seriesId, cancellationToken);
                 var res = new RemoteSearchResult
                 {
                     Name = metadata.Item.Name,
                     PremiereDate = metadata.Item.PremiereDate,
                     ProductionYear = metadata.Item.ProductionYear,
+                    ImageUrl = images.Any() ? images.First().Url : null,
                     ProviderIds = metadata.Item.ProviderIds,
                     SearchProviderName = Name
                 };

--- a/Jellyfin.Plugin.Anime/Providers/AniList/AniListApi.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniList/AniListApi.cs
@@ -371,6 +371,7 @@ query ($query: String, $type: MediaType) {
                 string _strContent = "";
                 using (WebClient client = new WebClient())
                 {
+                    client.Headers.Add("User-Agent", Constants.UserAgent);
                     var values = new System.Collections.Specialized.NameValueCollection();
 
                     var response = await Task.Run(() => client.UploadValues(new Uri(link),values));

--- a/Jellyfin.Plugin.Anime/Providers/AniList/AniListSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniList/AniListSeriesProvider.cs
@@ -106,6 +106,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
         {
             return _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             });
@@ -160,6 +161,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
         {
             return _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             });

--- a/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchApi.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchApi.cs
@@ -297,6 +297,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniSearch
                 string _strContent = "";
                 using (WebClient client = new WebClient())
                 {
+                    client.Headers.Add("User-Agent", Constants.UserAgent);
                     Task<string> async_content = client.DownloadStringTaskAsync(link);
                     _strContent = await async_content;
                 }

--- a/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchSeriesProvider.cs
@@ -98,6 +98,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniSearch
         {
             return _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             });
@@ -151,6 +152,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniSearch
         {
             return _httpClient.GetResponse(new HttpRequestOptions
             {
+                UserAgent = Constants.UserAgent,
                 CancellationToken = cancellationToken,
                 Url = url
             });

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-anime"
 guid: "a4df60c5-6ab4-412a-8f79-2cab93fb2bc5"
-version: "4"
+version: "5"
 jellyfin_version: "10.3.0"
 owner: "jellyfin"
 nicename: "Anime"


### PR DESCRIPTION
Somewhat recently it seems AniDB started responding with 403 when a request for the anime titles didn't include a User-Agent header (#50). This PR fixes that, so searching will re-download the anime titles and work again.

Additionally, since searching already involves querying for the full metadata of an anime, we can include ImageUrls in the results for free.

<details><summary>Screenshots</summary>
<p>

![search-image](https://user-images.githubusercontent.com/5846349/76180947-8487d980-618d-11ea-9173-6602cd559b49.png)

</p>
</details>