### PR TITLE
Fix building against Jellyfin 10.5.0

### DIFF
--- a/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj
+++ b/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Anime</RootNamespace>
     <AssemblyVersion>4.0.0</AssemblyVersion>
     <FileVersion>4.0.0</FileVersion>


### PR DESCRIPTION
Trying to build the plugin as is on now that Jellyfin 10.5 has been released results in the following error:

```console
$ docker run --rm -v "$PWD:/app" -w /app mcr.microsoft.com/dotnet/core/sdk:3.1 dotnet publish --configuration Release --output bin
/app/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj : error NU1202: 
Package Jellyfin.Controller 10.5.0 is not compatible with netstandard2.0
(.NETStandard,Version=v2.0). Package Jellyfin.Controller 10.5.0 supports:
netstandard2.1 (.NETStandard,Version=v2.1) [/app/Jellyfin.Plugin.Anime.sln]
```