### PR TITLE
Update AniDB CDN url and move all URLs to https

### DIFF
--- a/Jellyfin.Plugin.Anime/Providers/AniDB/AniDbExternalId.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/AniDbExternalId.cs
@@ -17,6 +17,6 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB
             => ProviderNames.AniDb;
 
         public string UrlFormatString
-            => "http://anidb.net/perl-bin/animedb.pl?show=anime&aid={0}";
+            => "https://anidb.net/perl-bin/animedb.pl?show=anime&aid={0}";
     }
 }

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Identity/AniDbTitleDownloader.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Identity
         /// <summary>
         /// The URL for retrieving a list of all anime titles and their AniDB IDs.
         /// </summary>
-        private const string TitlesUrl = "http://anidb.net/api/anime-titles.xml.gz";
+        private const string TitlesUrl = "https://anidb.net/api/anime-titles.xml.gz";
 
         private static readonly HttpClient _httpClient;
         private readonly ILogger _logger;

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbImageProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbImageProvider.cs
@@ -98,7 +98,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
                     {
                         if (reader.NodeType == XmlNodeType.Element && reader.Name == "picture")
                         {
-                            return "http://img7.anidb.net/pics/anime/" + reader.ReadElementContentAsString();
+                            return "https://cdn.anidb.net/images/main/" + reader.ReadElementContentAsString();
                         }
                     }
                 }

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -26,13 +26,13 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
     public class AniDbSeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasOrder
     {
         private const string SeriesDataFile = "series.xml";
-        private const string SeriesQueryUrl = "http://api.anidb.net:9001/httpapi?request=anime&client={0}&clientver=1&protover=1&aid={1}";
+        private const string SeriesQueryUrl = "https://api.anidb.net:9001/httpapi?request=anime&client={0}&clientver=1&protover=1&aid={1}";
         private const string ClientName = "mediabrowser";
 
         // AniDB has very low request rate limits, a minimum of 2 seconds between requests, and an average of 4 seconds between requests
         public static readonly RateLimiter RequestLimiter = new RateLimiter(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
         private static readonly int[] IgnoredTagIds = { 6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289 };
-        private static readonly Regex AniDbUrlRegex = new Regex(@"http://anidb.net/\w+ \[(?<name>[^\]]*)\]");
+        private static readonly Regex AniDbUrlRegex = new Regex(@"https?://anidb.net/\w+ \[(?<name>[^\]]*)\]");
         private readonly IApplicationPaths _appPaths;
         private readonly IHttpClient _httpClient;
 
@@ -711,7 +711,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
                         var picture = seiyuu.Attribute("picture");
                         if (picture != null && !string.IsNullOrEmpty(picture.Value))
                         {
-                            person.Image = "http://img7.anidb.net/pics/anime/" + picture.Value;
+                            person.Image = "https://cdn.anidb.net/images/main/" + picture.Value;
                         }
 
                         var id = seiyuu.Attribute("id");

--- a/Jellyfin.Plugin.Anime/Providers/AniList/AniListExternalId.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniList/AniListExternalId.cs
@@ -16,6 +16,6 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
             => ProviderNames.AniList;
 
         public string UrlFormatString
-            => "http://anilist.co/anime/{0}/";
+            => "https://anilist.co/anime/{0}/";
     }
 }

--- a/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchApi.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchApi.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.Providers;
 namespace Jellyfin.Plugin.Anime.Providers.AniSearch
 {
     /// <summary>
-    /// API for http://anisearch.com
+    /// API for https://anisearch.com
     /// Anisearch does not have an API interface to work with
     /// </summary>
     internal class AniSearchApi

--- a/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchExternalId.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniSearch/AniSearchExternalId.cs
@@ -16,6 +16,6 @@ namespace Jellyfin.Plugin.Anime.Providers.AniSearch
             => ProviderNames.AniSearch;
 
         public string UrlFormatString
-            => "http://www.anisearch.com/anime/{0}";
+            => "https://www.anisearch.com/anime/{0}";
     }
 }


### PR DESCRIPTION
AniDB stopped working on img7.anidb.net yesterday. The new one is cdn.anidb.net.

The correct way of doing it would be something like this: https://github.com/ShokoAnime/ShokoServer/pull/827 But that requires a login and the UDP API.