### PR TITLE
Fix linq null reference in Kitsu

### DIFF
--- a/Jellyfin.Plugin.Anime/Providers/KitsuIO/Metadata/KitsuIoSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/KitsuIO/Metadata/KitsuIoSeriesProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -78,7 +79,8 @@ namespace Jellyfin.Plugin.Anime.Providers.KitsuIO.Metadata
                         ? null
                         : (float?) float.Parse(seriesInfo.Data.Attributes.AverageRating, System.Globalization.CultureInfo.InvariantCulture) / 10,
                     ProviderIds = new Dictionary<string, string>() {{ProviderNames.KitsuIo, kitsuId}},
-                    Genres = seriesInfo.Included.Select(x => x.Attributes.Name).ToArray(),
+                    Genres = seriesInfo.Included?.Select(x => x.Attributes.Name).ToArray()
+                             ?? Array.Empty<string>()
                 };
                 GenreHelper.CleanupGenres(result.Item);
                 StoreImageUrl(kitsuId, seriesInfo.Data.Attributes.PosterImage.Original.ToString(), "image");


### PR DESCRIPTION
``` 
[2020-07-19 23:21:59.505 +00:00] [ERR] [19] MediaBrowser.Providers.TV.SeriesMetadataService: Error in "Kitsu"
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Select[TSource,TResult](IEnumerable`1 source, Func`2 selector)
   at Jellyfin.Plugin.Anime.Providers.KitsuIO.Metadata.KitsuIoSeriesProvider.GetMetadata(SeriesInfo info, CancellationToken cancellationToken)
   at MediaBrowser.Providers.Manager.MetadataService`2.ExecuteRemoteProviders(MetadataResult`1 temp, String logName, TIdType id, IEnumerable`1 providers, CancellationToken cancellationToken)
```