### PR TITLE
revert to http since api.anidb.net does not support https

### DIFF
--- a/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj
+++ b/Jellyfin.Plugin.Anime/Jellyfin.Plugin.Anime.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Anime</RootNamespace>
-    <AssemblyVersion>9.0.0.0</AssemblyVersion>
-    <FileVersion>9.0.0.0</FileVersion>
+    <AssemblyVersion>10.0.0.0</AssemblyVersion>
+    <FileVersion>10.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -32,7 +32,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
         // AniDB has very low request rate limits, a minimum of 2 seconds between requests, and an average of 4 seconds between requests
         public static readonly RateLimiter RequestLimiter = new RateLimiter(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
         private static readonly int[] IgnoredTagIds = { 6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289 };
-        private static readonly Regex AniDbUrlRegex = new Regex(@"http?://anidb.net/\w+ \[(?<name>[^\]]*)\]");
+        private static readonly Regex AniDbUrlRegex = new Regex(@"https?://anidb.net/\w+ \[(?<name>[^\]]*)\]");
         private readonly IApplicationPaths _appPaths;
         private readonly IHttpClient _httpClient;
 

--- a/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniDB/Metadata/AniDbSeriesProvider.cs
@@ -26,13 +26,13 @@ namespace Jellyfin.Plugin.Anime.Providers.AniDB.Metadata
     public class AniDbSeriesProvider : IRemoteMetadataProvider<Series, SeriesInfo>, IHasOrder
     {
         private const string SeriesDataFile = "series.xml";
-        private const string SeriesQueryUrl = "https://api.anidb.net:9001/httpapi?request=anime&client={0}&clientver=1&protover=1&aid={1}";
+        private const string SeriesQueryUrl = "http://api.anidb.net:9001/httpapi?request=anime&client={0}&clientver=1&protover=1&aid={1}";
         private const string ClientName = "mediabrowser";
 
         // AniDB has very low request rate limits, a minimum of 2 seconds between requests, and an average of 4 seconds between requests
         public static readonly RateLimiter RequestLimiter = new RateLimiter(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(5));
         private static readonly int[] IgnoredTagIds = { 6, 22, 23, 60, 128, 129, 185, 216, 242, 255, 268, 269, 289 };
-        private static readonly Regex AniDbUrlRegex = new Regex(@"https?://anidb.net/\w+ \[(?<name>[^\]]*)\]");
+        private static readonly Regex AniDbUrlRegex = new Regex(@"http?://anidb.net/\w+ \[(?<name>[^\]]*)\]");
         private readonly IApplicationPaths _appPaths;
         private readonly IHttpClient _httpClient;
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Anime"
 guid: "a4df60c5-6ab4-412a-8f79-2cab93fb2bc5"
-version: "9.0.0.0"
+version: "10.0.0.0"
 targetAbi: "10.6.0.0"
 owner: "jellyfin"
 overview: "Manage your anime from Jellyfin"


### PR DESCRIPTION
Reverting some of the changes introduced in #73 since non of the anidb api's support https (see [discussion](https://anidb.net/forum/thread/101567#c462460)).
Closes #85 