### PR TITLE
Populate 'Original title' field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.1-experimental
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS base
+
+WORKDIR /src
+ENV \
+    BaseIntermediateOutputPath=/obj/
+
+FROM base AS build
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.nuget \
+    --mount=type=tmpfs,target=/obj \
+    dotnet build --configuration Debug --output /out
+
+FROM base AS release
+RUN --mount=target=.,rw \
+    --mount=type=cache,target=/root/.nuget \
+    --mount=type=tmpfs,target=/obj \
+    dotnet publish --configuration Release --output /out
+
+FROM scratch AS final
+COPY --from=release /out/Jellyfin.Plugin.* /

--- a/Jellyfin.Plugin.Anime/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Anime/Configuration/PluginConfiguration.cs
@@ -30,6 +30,7 @@ namespace Jellyfin.Plugin.Anime.Configuration
         public PluginConfiguration()
         {
             TitlePreference = TitlePreferenceType.Localized;
+            OriginalTitlePreference = TitlePreferenceType.JapaneseRomaji;
             MaxGenres = 5;
             TidyGenreList = true;
             TitleCaseGenres = false;
@@ -39,6 +40,8 @@ namespace Jellyfin.Plugin.Anime.Configuration
         }
 
         public TitlePreferenceType TitlePreference { get; set; }
+
+        public TitlePreferenceType OriginalTitlePreference { get; set; }
 
         public int MaxGenres { get; set; }
 

--- a/Jellyfin.Plugin.Anime/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Anime/Configuration/configPage.html
@@ -18,6 +18,14 @@
                                 <option id="optLanguageJapaneseRomaji" value="JapaneseRomaji">Romaji</option>
                             </select>
                         </div>
+                        <div class="selectContainer">
+                            <label class="selectLabel" for="originalTitleLanguage">Original Title Language</label>
+                            <select is="emby-select" id="originalTitleLanguage" name="originalTitleLanguage" class="emby-select-withcolor emby-select">
+                                <option id="optLanguageLocalized" value="Localized">Localized</option>
+                                <option id="optLanguageJapanese" value="Japanese">Japanese</option>
+                                <option id="optLanguageJapaneseRomaji" value="JapaneseRomaji">Romaji</option>
+                            </select>
+                        </div>
                         <div class="inputContainer">
                             <label class="inputeLabel inputLabelUnfocused" for="chkMaxGenres">Max Genres</label>
                             <input id="chkMaxGenres" name="chkMaxGenres" type="number" is="emby-input" min="0" />
@@ -72,6 +80,7 @@
 
                         ApiClient.getPluginConfiguration(AnimeConfigurationPage.pluginUniqueId).then(function (config) {
                             document.getElementById('titleLanguage').value = config.TitlePreference;
+                            document.getElementById('originalTitleLanguage').value = config.OriginalTitlePreference;
                             document.getElementById('chkMaxGenres').value = config.MaxGenres;
                             document.getElementById('chkTitleCaseGenres').checked = config.TitleCaseGenres;
                             document.getElementById('chkTidyGenres').checked = config.TidyGenreList;
@@ -88,6 +97,7 @@
 
                         ApiClient.getPluginConfiguration(AnimeConfigurationPage.pluginUniqueId).then(function (config) {
                             config.TitlePreference = document.getElementById('titleLanguage').value;
+                            config.OriginalTitlePreference = document.getElementById('originalTitleLanguage').value;
                             config.MaxGenres = document.getElementById('chkMaxGenres').value;
                             config.TitleCaseGenres = document.getElementById('chkTitleCaseGenres').checked;
                             config.TidyGenreList = document.getElementById('chkTidyGenres').checked;

--- a/Jellyfin.Plugin.Anime/Providers/AniList/ApiModel.cs
+++ b/Jellyfin.Plugin.Anime/Providers/AniList/ApiModel.cs
@@ -60,10 +60,9 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public string GetPreferredTitle(string language)
+        public string GetPreferredTitle(TitlePreferenceType preference, string language)
         {
-            PluginConfiguration config = Plugin.Instance.Configuration;
-            if (config.TitlePreference == TitlePreferenceType.Localized)
+            if (preference == TitlePreferenceType.Localized)
             {
                 if (language == "en")
                 {
@@ -74,7 +73,7 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
                     return this.title.native;
                 }
             }
-            if (config.TitlePreference == TitlePreferenceType.Japanese)
+            if (preference == TitlePreferenceType.Japanese)
             {
                 return this.title.native;
             }
@@ -110,9 +109,10 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
         /// <returns></returns>
         public RemoteSearchResult ToSearchResult()
         {
+            PluginConfiguration config = Plugin.Instance.Configuration;
             return new RemoteSearchResult
             {
-                Name = this.GetPreferredTitle("en"),
+                Name = this.GetPreferredTitle(config.TitlePreference, "en"),
                 ProductionYear = this.startDate.year,
                 PremiereDate = this.GetStartDate(),
                 ImageUrl = this.GetImageUrl(),
@@ -227,8 +227,10 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
         /// <returns></returns>
         public Series ToSeries()
         {
+            PluginConfiguration config = Plugin.Instance.Configuration;
             var result = new Series {
-                Name = this.GetPreferredTitle("en"),
+                Name = this.GetPreferredTitle(config.TitlePreference, "en"),
+                OriginalTitle = this.GetPreferredTitle(config.OriginalTitlePreference, "en"),
                 Overview = this.description,
                 ProductionYear = this.startDate.year,
                 PremiereDate = this.GetStartDate(),
@@ -259,8 +261,10 @@ namespace Jellyfin.Plugin.Anime.Providers.AniList
         /// <returns></returns>
         public Movie ToMovie()
         {
+            PluginConfiguration config = Plugin.Instance.Configuration;
             return new Movie {
-                Name = this.GetPreferredTitle("en"),
+                Name = this.GetPreferredTitle(config.TitlePreference, "en"),
+                OriginalTitle = this.GetPreferredTitle(config.OriginalTitlePreference, "en"),
                 Overview = this.description,
                 ProductionYear = this.startDate.year,
                 PremiereDate = this.GetStartDate(),


### PR DESCRIPTION
adds a config option that reuses the title preference to advise the provider to pull an alternate title we use for populating the original title metadata field

this can be used to display titles in english while still being able to search for the romanji (or vise versa)

here is how I use it (title pref: jpn, orig title: english)
![image](https://user-images.githubusercontent.com/3930615/99911239-e328bf80-2cea-11eb-91ac-fae0fe700af4.png)
